### PR TITLE
睡眠時間のバリデーション

### DIFF
--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -345,6 +345,7 @@ function removeActivityRecord(idx) {
 function checkSleepData() {
   const errors = []
   let isAfter4Yesterday = true
+  let isBefore4Today = true
   let isStartTimeBeforeEndTime = true
   const After4Yesterday = new Date(
     selectedDateRef.value.getFullYear(),
@@ -352,11 +353,22 @@ function checkSleepData() {
     selectedDateRef.value.getDate() - 1,
     16
   )
+  const Before4Today = new Date(
+    selectedDateRef.value.getFullYear(),
+    selectedDateRef.value.getMonth(),
+    selectedDateRef.value.getDate(),
+    15, 59
+  )
 
   for (let s of sleepRecordsRef.value) {
     const startDateTime = new Date(s.sleep_start_time)
+    const endDateTime = new Date(s.sleep_end_time)
+
     if (startDateTime < After4Yesterday) {
       isAfter4Yesterday = false
+    }
+    if (endDateTime > Before4Today) {
+      isBefore4Today = false
     }
     if (s.sleep_start_time > s.sleep_end_time) {
       isStartTimeBeforeEndTime = false
@@ -365,6 +377,9 @@ function checkSleepData() {
 
   if (!isAfter4Yesterday) {
     errors.push("・開始時間は前日の16時以降にしてください")
+  }
+  if (!isBefore4Today) {
+    errors.push("・終了時間は当日の15時59分より前にしてください")
   }
   if (!isStartTimeBeforeEndTime) {
     errors.push("・開始時間は終了時間より前にしてください")

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -105,7 +105,7 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-dark" data-bs-dismiss="modal" @click="upsertMood">
+          <button class="btn btn-dark" data-bs-dismiss="modal" @click="checkSleepData">
             保存
           </button>
         </div>
@@ -290,7 +290,7 @@ async function fetchDailyMood() {
             new Date(sleep.sleep_start_time.replace(" ", "T")),
             new Date(sleep.sleep_end_time.replace(" ", "T"))
           )
-      );
+        );
       activityRecordsRef.value = !Array.isArray(response._data[0].activities)
         ? []
         : response._data[0].activities.map(activity =>
@@ -299,7 +299,7 @@ async function fetchDailyMood() {
             new Date(activity.activity_end_time.replace(" ", "T")),
             activity.activity_type
           )
-      );
+        );
       actualSleepMinutesRef.value = response._data[0].sleep_minutes;
       memoRef.value = response._data[0].memo;
     },
@@ -340,6 +340,18 @@ function removeActivityRecord(idx) {
   const copiedActivityRecord = [...activityRecordsRef.value];
   copiedActivityRecord.splice(idx, 1);
   activityRecordsRef.value = copiedActivityRecord;
+}
+
+function checkSleepData() {
+  const errors = []
+  if (sleepRecordsRef.value[0].sleep_start_time > sleepRecordsRef.value[0].sleep_end_time) {
+    errors.push("開始時間は終了時間より前にしてください")
+  }
+  if (errors.length == 0) {
+    upsertMood();
+  } else {
+    alert(errors)
+  }
 }
 
 watch(startDate, tableRowsRefresh);

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -344,19 +344,35 @@ function removeActivityRecord(idx) {
 
 function checkSleepData() {
   const errors = []
+  let isAfter4Yesterday = true
   let isStartTimeBeforeEndTime = true
+  const After4Yesterday = new Date(
+    selectedDateRef.value.getFullYear(),
+    selectedDateRef.value.getMonth(),
+    selectedDateRef.value.getDate() - 1,
+    16
+  )
+
   for (let s of sleepRecordsRef.value) {
+    const startDateTime = new Date(s.sleep_start_time)
+    if (startDateTime < After4Yesterday) {
+      isAfter4Yesterday = false
+    }
     if (s.sleep_start_time > s.sleep_end_time) {
       isStartTimeBeforeEndTime = false
     }
   }
+
+  if (!isAfter4Yesterday) {
+    errors.push("・開始時間は前日の16時以降にしてください")
+  }
   if (!isStartTimeBeforeEndTime) {
-    errors.push("開始時間は終了時間より前にしてください")
+    errors.push("・開始時間は終了時間より前にしてください")
   }
   if (errors.length == 0) {
     upsertMood();
   } else {
-    alert(errors)
+    alert(errors.join("\n"))
   }
 }
 

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -382,10 +382,10 @@ function checkSleepData() {
   const ascEndDateTimeArray = [...endDateTimeArray].sort((a, b) => new Date(a) - new Date(b));
   let hasDuplicateSleepTime = false
 
-  if (ascStartDateTimeArray[1] < ascEndDateTimeArray[0] ||
-    ascStartDateTimeArray[2] < ascEndDateTimeArray[1] ||
-    ascStartDateTimeArray[3] < ascEndDateTimeArray[2]) {
-    hasDuplicateSleepTime = true
+  for (let i = 0; i < ascStartDateTimeArray.length; i++) {
+    if (ascStartDateTimeArray[i + 1] < ascEndDateTimeArray[i]) {
+      hasDuplicateSleepTime = true
+    }
   }
 
   const errors = []

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -110,7 +110,7 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-dark" data-bs-dismiss="modal" @click="checkSleepData">
+          <button class="btn btn-dark" @click="checkSleepData">
             保存
           </button>
         </div>
@@ -402,8 +402,10 @@ function checkSleepData() {
   }
   if (errors.length == 0) {
     upsertMood();
+    modal.hide()
   } else {
     alert(errors.join("\n"))
+    modal.show();
   }
 }
 

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -376,9 +376,15 @@ function checkSleepData() {
     startDateTimeArray.push(startDateTime)
     endDateTimeArray.push(endDateTime)
 
-    isBeforePM4Yesterday = startDateTime < afterPM4Yesterday
-    isAfterPM4Today = endDateTime > beforePM4Today
-    isStartTimeAfterEndTime = startDateTime > endDateTime
+    if (startDateTime < afterPM4Yesterday) {
+      isBeforePM4Yesterday = true
+    }
+    if (endDateTime > beforePM4Today) {
+      isAfterPM4Today = true
+    }
+    if (startDateTime > endDateTime) {
+      isStartTimeAfterEndTime = true
+    }
   }
 
   const ascStartDateTimeArray = [...startDateTimeArray].sort((a, b) => new Date(a) - new Date(b));

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -344,7 +344,13 @@ function removeActivityRecord(idx) {
 
 function checkSleepData() {
   const errors = []
-  if (sleepRecordsRef.value[0].sleep_start_time > sleepRecordsRef.value[0].sleep_end_time) {
+  let isStartTimeBeforeEndTime = true
+  for (let s of sleepRecordsRef.value) {
+    if (s.sleep_start_time > s.sleep_end_time) {
+      isStartTimeBeforeEndTime = false
+    }
+  }
+  if (!isStartTimeBeforeEndTime) {
     errors.push("開始時間は終了時間より前にしてください")
   }
   if (errors.length == 0) {

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -348,21 +348,21 @@ function removeActivityRecord(idx) {
 }
 
 function checkSleepData() {
-  const After4Yesterday = new Date(
+  const afterPM4Yesterday = new Date(
     selectedDateRef.value.getFullYear(),
     selectedDateRef.value.getMonth(),
     selectedDateRef.value.getDate() - 1,
     16
   )
-  const Before4Today = new Date(
+  const beforePM4Today = new Date(
     selectedDateRef.value.getFullYear(),
     selectedDateRef.value.getMonth(),
     selectedDateRef.value.getDate(),
     15, 59
   )
 
-  let isAfter4Yesterday = true
-  let isBefore4Today = true
+  let isAfterPM4Yesterday = true
+  let isBeforePM4Today = true
   let isStartTimeBeforeEndTime = true
   const startDateTimeArray = []
   const endDateTimeArray = []
@@ -372,11 +372,11 @@ function checkSleepData() {
     startDateTimeArray.push(startDateTime)
     endDateTimeArray.push(endDateTime)
 
-    if (startDateTime < After4Yesterday) {
-      isAfter4Yesterday = false
+    if (startDateTime < afterPM4Yesterday) {
+      isAfterPM4Yesterday = false
     }
-    if (endDateTime > Before4Today) {
-      isBefore4Today = false
+    if (endDateTime > beforePM4Today) {
+      isBeforePM4Today = false
     }
     if (startDateTime > endDateTime) {
       isStartTimeBeforeEndTime = false
@@ -394,10 +394,10 @@ function checkSleepData() {
   }
 
   const errors = []
-  if (!isAfter4Yesterday) {
+  if (!isAfterPM4Yesterday) {
     errors.push("・開始時間は前日の16時以降にしてください")
   }
-  if (!isBefore4Today) {
+  if (!isBeforePM4Today) {
     errors.push("・終了時間は当日の15時59分より前にしてください")
   }
   if (!isStartTimeBeforeEndTime) {

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -19,6 +19,9 @@
         </div>
         <div class="modal-body p-4">
           <div class="mb-3">
+            <p class="text-danger" style="white-space: pre-line">
+              {{ validationErrors }}
+            </p>
             <div class="form-label fw-bold">気分</div>
             <div class="d-flex aligh-item-center justify-content-center">
               <div>
@@ -177,6 +180,7 @@ const activityTypes = ["運動", "通勤", "入浴", "通院"]
 const sumSleepMinutes = computed(() => sleepRecoredsRefWrap.sleepRecordsRef.value.reduce((a, c) => a + c.sleepMinutes(), 0))
 const actualSleepMinutes = computed(() => actualSleepMinutesRef.value === null ? "-" : actualSleepMinutesRef.value)
 const sleepEfficiency = computed(() => sumSleepMinutes.value === 0 ? "-" : ((actualSleepMinutesRef.value / sumSleepMinutes.value) * 100).toFixed(2))
+const validationErrors = ref("")
 
 let modal = null;
 const domLayout = "autoHeight";
@@ -404,7 +408,7 @@ function checkSleepData() {
     upsertMood();
     modal.hide()
   } else {
-    alert(errors.join("\n"))
+    validationErrors.value = errors.join("\n")
     modal.show();
   }
 }

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -407,6 +407,7 @@ function checkSleepData() {
   if (errors.length == 0) {
     upsertMood();
     modal.hide()
+    validationErrors.value = ""
   } else {
     validationErrors.value = errors.join("\n")
     modal.show();

--- a/src/components/ActivitiesLog.vue
+++ b/src/components/ActivitiesLog.vue
@@ -361,9 +361,9 @@ function checkSleepData() {
     15, 59
   )
 
-  let isAfterPM4Yesterday = true
-  let isBeforePM4Today = true
-  let isStartTimeBeforeEndTime = true
+  let isBeforePM4Yesterday = false
+  let isAfterPM4Today = false
+  let isStartTimeAfterEndTime = false
   const startDateTimeArray = []
   const endDateTimeArray = []
   for (let s of sleepRecordsRef.value) {
@@ -372,15 +372,9 @@ function checkSleepData() {
     startDateTimeArray.push(startDateTime)
     endDateTimeArray.push(endDateTime)
 
-    if (startDateTime < afterPM4Yesterday) {
-      isAfterPM4Yesterday = false
-    }
-    if (endDateTime > beforePM4Today) {
-      isBeforePM4Today = false
-    }
-    if (startDateTime > endDateTime) {
-      isStartTimeBeforeEndTime = false
-    }
+    isBeforePM4Yesterday = startDateTime < afterPM4Yesterday
+    isAfterPM4Today = endDateTime > beforePM4Today
+    isStartTimeAfterEndTime = startDateTime > endDateTime
   }
 
   const ascStartDateTimeArray = [...startDateTimeArray].sort((a, b) => new Date(a) - new Date(b));
@@ -394,13 +388,13 @@ function checkSleepData() {
   }
 
   const errors = []
-  if (!isAfterPM4Yesterday) {
+  if (isBeforePM4Yesterday) {
     errors.push("・開始時間は前日の16時以降にしてください")
   }
-  if (!isBeforePM4Today) {
+  if (isAfterPM4Today) {
     errors.push("・終了時間は当日の15時59分より前にしてください")
   }
-  if (!isStartTimeBeforeEndTime) {
+  if (isStartTimeAfterEndTime) {
     errors.push("・開始時間は終了時間より前にしてください")
   }
   if (hasDuplicateSleepTime) {


### PR DESCRIPTION
- [x] 睡眠時間が重なっていないか(睡眠1の終了時刻と睡眠2の開始時刻が同時刻なのはOK)
- [x] 入力画面の日付と合わないデータ(例：12/14の入力画面なのに12/22の睡眠記録を入力) => 前日16:00-当日15:59のあいだで記録できるようにする
- [x] 睡眠開始時刻が睡眠終了時刻よりも後はNG
- [x] 「保存」を押したときにバリデーションする
- [x] ActivitiesLog.Vueでバリデーション処理をする
- [x] エラーメッセージは睡眠記録画面の日付の下に赤文字で表示する


![479F4CE9-D763-4B74-83DE-02160B505046](https://user-images.githubusercontent.com/61221142/209487948-ce2ed471-ce25-4163-b128-a6dacfb1a033.jpeg)


